### PR TITLE
Modernize python

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,7 +1,6 @@
 #pybind11
 find_package(PythonLibs REQUIRED)
 include_directories(${PYTHON_INCLUDE_DIRS})
-set( PYBIND11_CPP_STANDARD "-std=c++14" )
 add_subdirectory( pybind11 )
 set(PYBIND11_PYTHON_VERSION 3.6)
 #end pybind11

--- a/python/examples/CMakeLists.txt
+++ b/python/examples/CMakeLists.txt
@@ -9,5 +9,5 @@ foreach (example  eval_beam_shape
                   eval_detection_cluster
 
         )
-        add_test(NAME example_${example} COMMAND python ${PYTHON_EXAMPLE_DIR}/${example}.py hide)
+        add_test(NAME example_${example} COMMAND python3 ${PYTHON_EXAMPLE_DIR}/${example}.py hide)
 endforeach()

--- a/python/tests/CMakeLists.txt
+++ b/python/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ foreach (test  test_approx_function
                test_radar_config
                test_radar_generate
         )
-        add_test(NAME python_${test} COMMAND python ${PYTHON_TEST_DIR}/${test}.py)
+        add_test(NAME python_${test} COMMAND python3 ${PYTHON_TEST_DIR}/${test}.py)
 endforeach()
 
 EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_BINARY_DIR}/python/tests/test_devel_python.so" "${PYTHON_TEST_DIR}/test_devel_python.so")

--- a/src/radar/radar_data_queue.cpp
+++ b/src/radar/radar_data_queue.cpp
@@ -1,4 +1,4 @@
-
+#include <stdexcept>
 
 #include <radsim/radar/radar_data_queue.hpp>
 


### PR DESCRIPTION
This PR is meant to solve the modernization problems (changing to c++20) with the Python package. See issue: https://github.com/stefoss23/bkrs/issues/46.

Some changes:
- The use of Python3 is specified in the tests
- Pybind11 is upgraded to a newer version